### PR TITLE
Adds a command on Sublime Text Command Palette for Rspec toggle

### DIFF
--- a/RspecToggle/RspecToggle.sublime-commands
+++ b/RspecToggle/RspecToggle.sublime-commands
@@ -1,0 +1,6 @@
+[
+  {
+    "caption": "Rspec Toggle: toggle test/implementation file",
+    "command": "rspec_toggle"
+  }
+]


### PR DESCRIPTION
I'm adding the RSpec toggle for Sublime Text command palette, doing this you will be able to toggle between implementation/test file using the command palette.  

@fnando, do you have a separated repository for this plugin ? I couldn't find it on your github repos. 

![](http://f.cl.ly/items/3b0r3U3I1l2l331Q1V0s/Screen%20Shot%202013-04-03%20at%2010.12.53%20AM.png)
